### PR TITLE
Fix ALL technologies

### DIFF
--- a/sql/all.sql
+++ b/sql/all.sql
@@ -111,8 +111,8 @@ UNION ALL
     app
 UNION ALL
   SELECT
-    ARRAY_TO_STRING(ARRAY_AGG(DISTINCT category IGNORE NULLS ORDER BY category), ', ') AS category,
-    'ALL' AS app
+    'ALL' AS app,
+    ARRAY_TO_STRING(ARRAY_AGG(DISTINCT category IGNORE NULLS ORDER BY category), ', ') AS category
   FROM
     latest_technologies
 ), summary_stats AS (

--- a/sql/monthly.sql
+++ b/sql/monthly.sql
@@ -126,8 +126,8 @@ UNION ALL
     app
 UNION ALL
   SELECT
-    ARRAY_TO_STRING(ARRAY_AGG(DISTINCT category IGNORE NULLS ORDER BY category), ', ') AS category,
-    'ALL' AS app
+    'ALL' AS app,
+    ARRAY_TO_STRING(ARRAY_AGG(DISTINCT category IGNORE NULLS ORDER BY category), ', ') AS category
   FROM
     TECHNOLOGIES_RELEASE
 ), summary_stats AS (


### PR DESCRIPTION
Order takes precedence over field naming for `UNION ALL` 🤦 